### PR TITLE
Scaling issue fix for high/low voltage/frequency protection on 1P LV inverters.

### DIFF
--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -319,11 +319,13 @@ number:
     unit_of_measurement: "V"
     device_class: voltage
     entity_category: config
-    register_type: holding
+    register_type: holding    
     min_value: 100
     max_value: 290
     step: 1
     address: 287
+    filters:
+      - multiply: 0.01    
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"
@@ -341,6 +343,8 @@ number:
     max_value: 290
     step: 1
     address: 288
+    filters:
+      - multiply: 100    
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"

--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -324,7 +324,7 @@ number:
     max_value: 290
     step: 1
     address: 287
-    multiply: 0.01    
+    multiply: 0.1    
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"
@@ -342,7 +342,7 @@ number:
     max_value: 290
     step: 1
     address: 288
-    multiply: 100    
+    multiply: 0.1    
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"
@@ -360,6 +360,7 @@ number:
     max_value: 65
     step: 1
     address: 289
+    multiply: 0.01
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"
@@ -377,6 +378,7 @@ number:
     max_value: 65
     step: 1
     address: 290
+    multiply: 0.01
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"

--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -324,8 +324,7 @@ number:
     max_value: 290
     step: 1
     address: 287
-    filters:
-      - multiply: 0.01    
+    multiply: 0.01    
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"
@@ -343,8 +342,7 @@ number:
     max_value: 290
     step: 1
     address: 288
-    filters:
-      - multiply: 100    
+    multiply: 100    
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"

--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -324,7 +324,7 @@ number:
     max_value: 290
     step: 1
     address: 287
-    multiply: 0.1    
+    multiply: 10    
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"
@@ -342,7 +342,7 @@ number:
     max_value: 290
     step: 1
     address: 288
-    multiply: 0.1    
+    multiply: 10    
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"
@@ -360,7 +360,7 @@ number:
     max_value: 65
     step: 1
     address: 289
-    multiply: 0.01
+    multiply: 100
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"
@@ -378,7 +378,7 @@ number:
     max_value: 65
     step: 1
     address: 290
-    multiply: 0.01
+    multiply: 100
     value_type: U_WORD
     mode: box
     icon: "mdi:sine-wave"


### PR DESCRIPTION
## Description

This fixes #113 . ie voltage/frequency protection value being reported too high because of missing scaling value.

## Changes relate to

<!-- Please select what this PR relates to (select one or more): -->
- [ ] Docs
- [ ] Deye 3P LP
- [ ] Deye 3P HV
- [ . ] Deye 1P LP
- [ ] Other
