### PR TITLE
Adding Power sensor state class for 1P LV inverters.

### DIFF
--- a/pv_inverter/packages/deye_hybrid_1p/battery.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/battery.yaml
@@ -120,6 +120,7 @@ sensor:
     address: 190
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: S_WORD
     icon: "mdi:lightning-bolt"

--- a/pv_inverter/packages/deye_hybrid_1p/gen.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/gen.yaml
@@ -77,6 +77,7 @@ sensor:
     address: 166
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: S_WORD
     icon: "mdi:engine"

--- a/pv_inverter/packages/deye_hybrid_1p/grid.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/grid.yaml
@@ -28,6 +28,7 @@ sensor:
     address: 167
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: S_WORD
     icon: "mdi:transmission-tower"
@@ -39,6 +40,7 @@ sensor:
     address: 168
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: S_WORD
     icon: "mdi:transmission-tower"
@@ -50,6 +52,7 @@ sensor:
     address: 169
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: S_WORD
     icon: "mdi:transmission-tower"

--- a/pv_inverter/packages/deye_hybrid_1p/inverter.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/inverter.yaml
@@ -87,6 +87,7 @@ sensor:
     address: 173
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: S_WORD
     icon: "mdi:solar-power"
@@ -98,6 +99,7 @@ sensor:
     address: 174
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: S_WORD
     icon: "mdi:solar-power"
@@ -110,6 +112,7 @@ sensor:
     address: 175
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: S_WORD
     icon: "mdi:solar-power"

--- a/pv_inverter/packages/deye_hybrid_1p/load.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/load.yaml
@@ -45,6 +45,7 @@ sensor:
     address: 176
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: S_WORD
     icon: "mdi:home-lightning-bolt"
@@ -56,6 +57,7 @@ sensor:
     address: 177
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: S_WORD
     icon: "mdi:home-lightning-bolt"
@@ -67,6 +69,7 @@ sensor:
     address: 178
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: S_WORD
     icon: "mdi:home-lightning-bolt"

--- a/pv_inverter/packages/deye_hybrid_1p/pv.yaml
+++ b/pv_inverter/packages/deye_hybrid_1p/pv.yaml
@@ -20,6 +20,7 @@ sensor:
     address: 186
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: U_WORD
     icon: "mdi:solar-power-variant"
@@ -32,6 +33,7 @@ sensor:
     address: 187
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: U_WORD
     icon: "mdi:solar-power-variant"
@@ -44,6 +46,7 @@ sensor:
     address: 188
     unit_of_measurement: "W"
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     value_type: U_WORD
     icon: "mdi:solar-power-variant"
@@ -54,11 +57,10 @@ sensor:
     id: pv4_power
     register_type: holding
     address: 189
-    unit_of_measurement: "V"
-    device_class: voltage
-    accuracy_decimals: 1
-    filters:
-      - multiply: 0.1
+    unit_of_measurement: "W"
+    device_class: power
+    state_class: "measurement"
+    accuracy_decimals: 0
     value_type: U_WORD
     icon: "mdi:solar-power-variant"
 
@@ -67,6 +69,7 @@ sensor:
     unit_of_measurement: "W"
     id: pv_power
     device_class: power
+    state_class: "measurement"
     accuracy_decimals: 0
     update_interval: 5s
     icon: "mdi:solar-power-variant"


### PR DESCRIPTION
## Description

<!-- Please describe the changes introduced in this pull request -->

Feature parity with 3P inverters in regard to power state class ( #82 ) to be able to add power sensors to home assistant energy dashboard (native).

Have also made correction to pv4 power sensor.

## Changes relate to

<!-- Please select what this PR relates to (select one or more): -->
- [ ] Docs
- [ ] Deye 3P LP
- [ ] Deye 3P HV
- [.] Deye 1P LP
- [ ] Other
