### PR TITLE
adding Grid Charge Start SOC modbus 191

### DIFF
--- a/pv_inverter/packages/deye_hybrid_3p/battery.yaml
+++ b/pv_inverter/packages/deye_hybrid_3p/battery.yaml
@@ -815,3 +815,16 @@ number:
     value_type: U_WORD
     mode: box
     icon: "mdi:battery-charging-50"
+
+  - platform: modbus_controller
+    modbus_controller_id: ${modbus_controller_id} 
+    name: "${name} Force Grid Charge Start SOC"
+    register_type: holding
+    address: 191
+    value_type: U_WORD
+    unit_of_measurement: "%"
+    icon: "mdi:battery-charging-high"
+    entity_category: config
+    min_value: 0
+    max_value: 100
+    step: 1


### PR DESCRIPTION
to be able to control the general battery charge start soc, controls for modbus 191 are needed.

## Description

<!-- Please describe the changes introduced in this pull request -->

## Changes relate to

<!-- Please select what this PR relates to (select one or more): -->
- [ ] Docs
- [x ] Deye 3P LP
- [ ] Deye 3P HV
- [ ] Deye 1P LP
- [ ] Other
technically all but i only use 3P LP